### PR TITLE
expose ParseQuery to parse query struct

### DIFF
--- a/rql.go
+++ b/rql.go
@@ -159,7 +159,7 @@ func (p *Parser) Parse(b []byte) (pr *Params, err error) {
 	return p.ParseQuery(*q)
 }
 
-// Parse Query parses the given struct into a Param object. It returns an error
+// ParseQuery parses the given struct into a Param object. It returns an error
 // if the filter JSON is invalid, or its values don't follow the schema of rql.
 func (p *Parser) ParseQuery(q Query) (pr *Params, err error) {
 	defer func() {

--- a/rql.go
+++ b/rql.go
@@ -154,6 +154,12 @@ func (p *Parser) Parse(b []byte) (pr *Params, err error) {
 	}()
 	q := new(Query)
 	must(q.UnmarshalJSON(b), "decoding buffer to Query")
+	return p.ParseQuery(*q)
+}
+
+// Parse Query parses the given struct into a Param object. It returns an error
+// if the filter JSON is invalid, or its values don't follow the schema of rql.
+func (p *Parser) ParseQuery(q Query) (pr *Params, err error) {
 	pr = &Params{
 		Limit: p.DefaultLimit,
 	}

--- a/rql.go
+++ b/rql.go
@@ -160,6 +160,16 @@ func (p *Parser) Parse(b []byte) (pr *Params, err error) {
 // Parse Query parses the given struct into a Param object. It returns an error
 // if the filter JSON is invalid, or its values don't follow the schema of rql.
 func (p *Parser) ParseQuery(q Query) (pr *Params, err error) {
+	defer func() {
+		if e := recover(); e != nil {
+			perr, ok := e.(ParseError)
+			if !ok {
+				panic(e)
+			}
+			err = perr
+			pr = nil
+		}
+	}()
 	pr = &Params{
 		Limit: p.DefaultLimit,
 	}

--- a/rql.go
+++ b/rql.go
@@ -153,7 +153,9 @@ func (p *Parser) Parse(b []byte) (pr *Params, err error) {
 		}
 	}()
 	q := new(Query)
-	must(q.UnmarshalJSON(b), "decoding buffer to Query")
+	if err := q.UnmarshalJSON(b); err != nil {
+	    return nil, &ParseError{"decoding buffer to *Query: "+ err.Error())
+	}
 	return p.ParseQuery(*q)
 }
 

--- a/rql.go
+++ b/rql.go
@@ -154,7 +154,7 @@ func (p *Parser) Parse(b []byte) (pr *Params, err error) {
 	}()
 	q := new(Query)
 	if err := q.UnmarshalJSON(b); err != nil {
-	    return nil, &ParseError{"decoding buffer to *Query: "+ err.Error())
+		return nil, &ParseError{"decoding buffer to *Query: " + err.Error()}
 	}
 	return p.ParseQuery(*q)
 }

--- a/rql.go
+++ b/rql.go
@@ -160,7 +160,7 @@ func (p *Parser) Parse(b []byte) (pr *Params, err error) {
 }
 
 // ParseQuery parses the given struct into a Param object. It returns an error
-// if the filter JSON is invalid, or its values don't follow the schema of rql.
+// if one of the query values don't follow the schema of rql.
 func (p *Parser) ParseQuery(q Query) (pr *Params, err error) {
 	defer func() {
 		if e := recover(); e != nil {

--- a/rql.go
+++ b/rql.go
@@ -142,16 +142,6 @@ func MustNewParser(c Config) *Parser {
 // Parse parses the given buffer into a Param object. It returns an error
 // if the JSON is invalid, or its values don't follow the schema of rql.
 func (p *Parser) Parse(b []byte) (pr *Params, err error) {
-	defer func() {
-		if e := recover(); e != nil {
-			perr, ok := e.(ParseError)
-			if !ok {
-				panic(e)
-			}
-			err = perr
-			pr = nil
-		}
-	}()
 	q := new(Query)
 	if err := q.UnmarshalJSON(b); err != nil {
 		return nil, &ParseError{"decoding buffer to *Query: " + err.Error()}


### PR DESCRIPTION
Just exposing a parse function that accepts the `Query` object to allow for greater control. Primary use case is to allow cleaner web framework integration and allow flatter query parameters  ie `?query={limit=..,offset=..}` vs `?limit=..&offset=..&filter={..}`.

On the web framework side this allows the framework to handle things like defaults and validation so that it can be consistent with the rest of the web project. Depending on the web framework (gin,goa) this may also allow it to auto document the structure better. 