### PR TITLE
add field naming support

### DIFF
--- a/config.go
+++ b/config.go
@@ -110,6 +110,10 @@ type Config struct {
 	// 	}
 	//
 	FieldSep string
+	// FieldNameFn is the function used to generate the external query field name.
+	// Example TODO
+	// Example Compare to ColumnFN
+	FieldNameFn func(string) string
 	// ColumnFn is the function that translate the struct field string into a table column.
 	// For example, given the following fields and their column names:
 	//


### PR DESCRIPTION
This allows setting an external naming convention that is different than the db column and will map accordingly. 

User can query `filter:{someField:5}` and it will be mapped to `where some_field = ?` following the functions. 

Needs documentation, tests coverage, will add next. 

User can add `name` struct tag to specify the name manually or they can add `FieldNameFn` to the config. 

it should be backwards compatible as it default to the current behavior. There is 1 TODO that I'm not sure is correct. 