### PR TITLE
Fix example for gorm

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ func GetUsers(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
-	err = db.Where(p.FilterExp, p.FilterArgs).
+	err = db.Where(p.FilterExp, p.FilterArgs...).
 		Offset(p.Offset).
 		Limit(p.Limit).
 		Order(p.Sort).
@@ -278,7 +278,7 @@ users, err = client.User.Query().
 must(err, "failed to query ent")
 
 // gorm
-err = db.Where(p.FilterExp, p.FilterArgs).
+err = db.Where(p.FilterExp, p.FilterArgs...).
 	Offset(p.Offset).
 	Limit(p.Limit).
 	Order(p.Sort).


### PR DESCRIPTION
without this fix, when using a filter using more than one column gorm would try to use the `FilterArgs` only on the first row.
gorm api reference:
https://github.com/go-gorm/gorm/blob/373bcf7aca01ef76c8ba5c3bc1ff191b020afc7b/chainable_api.go#L155