### PR TITLE
expose fields

### DIFF
--- a/config.go
+++ b/config.go
@@ -110,6 +110,15 @@ type Config struct {
 	// 	}
 	//
 	FieldSep string
+	// NameFn is a function that translates the incoming filter query field name to the field column name.
+	// For example, given the following query fields and their column names:
+	//
+	//	fullName => "full_name"
+	// 	httpPort => "http_port"
+	//
+	// By default the field name is expected to match the column.
+	//
+	NameFn func(string) string
 	// ColumnFn is the function that translate the struct field string into a table column.
 	// For example, given the following fields and their column names:
 	//
@@ -152,6 +161,7 @@ func (c *Config) defaults() error {
 	if c.ColumnFn == nil {
 		c.ColumnFn = Column
 	}
+
 	defaultString(&c.TagName, DefaultTagName)
 	defaultString(&c.OpPrefix, DefaultOpPrefix)
 	defaultString(&c.FieldSep, DefaultFieldSep)

--- a/rql.go
+++ b/rql.go
@@ -17,6 +17,7 @@ import (
 //go:generate easyjson -omit_empty -disallow_unknown_fields -snake_case rql.go
 
 // Query is the decoded result of the user input.
+//
 //easyjson:json
 type Query struct {
 	// Limit must be > 0 and <= to `LimitMaxValue`.
@@ -73,7 +74,6 @@ type Query struct {
 //		return nil, err
 //	}
 //	return users, nil
-//
 type Params struct {
 	// Limit represents the number of rows returned by the SELECT statement.
 	Limit int
@@ -106,8 +106,10 @@ func (p ParseError) Error() string {
 
 // field is a configuration of a struct field.
 type field struct {
-	// Name of the column.
+	// Name of the field.
 	Name string
+	// name of the column.
+	Column string
 	// Has a "sort" option in the tag.
 	Sortable bool
 	// Has a "filter" option in the tag.
@@ -203,7 +205,6 @@ func (p *Parser) ParseQuery(q *Query) (pr *Params, err error) {
 //	Username => username
 //	FullName => full_name
 //	HTTPCode => http_code
-//
 func Column(s string) string {
 	var b strings.Builder
 	for i := 0; i < len(s); i++ {
@@ -258,7 +259,7 @@ func (p *Parser) init() error {
 // in the parser according to its type and the options that were set on the tag.
 func (p *Parser) parseField(sf reflect.StructField) error {
 	f := &field{
-		Name:      p.ColumnFn(sf.Name),
+		Column:    p.ColumnFn(sf.Name),
 		CovertFn:  valueFn,
 		FilterOps: make(map[string]bool),
 	}
@@ -271,7 +272,9 @@ func (p *Parser) parseField(sf reflect.StructField) error {
 		case s == "filter":
 			f.Filterable = true
 		case strings.HasPrefix(opt, "column"):
-			f.Name = strings.TrimPrefix(opt, "column=")
+			f.Column = strings.TrimPrefix(opt, "column=")
+		case strings.HasPrefix(opt, "name"):
+			f.Name = strings.TrimPrefix(opt, "name=")
 		case strings.HasPrefix(opt, "layout"):
 			layout = strings.TrimPrefix(opt, "layout=")
 			// if it's one of the standard layouts, like: RFC822 or Kitchen.
@@ -289,6 +292,16 @@ func (p *Parser) parseField(sf reflect.StructField) error {
 			p.Log("Ignoring unknown option %q in struct tag", opt)
 		}
 	}
+
+	// backwards compatible
+	if f.Name == "" {
+		if p.NameFn != nil {
+			f.Name = p.NameFn(sf.Name)
+		} else {
+			f.Name = f.Column
+		}
+	}
+
 	var filterOps []Op
 	switch typ := indirect(sf.Type); typ.Kind() {
 	case reflect.Bool:
@@ -407,9 +420,11 @@ func (p *parseState) and(f map[string]interface{}) {
 			terms, ok := v.([]interface{})
 			expect(ok, "$and must be type array")
 			p.relOp(AND, terms)
+
 		case p.fields[k] != nil:
-			expect(p.fields[k].Filterable, "field %q is not filterable", k)
-			p.field(p.fields[k], v)
+			f := p.fields[k]
+			expect(f.Filterable, "field %q is not filterable", k)
+			p.field(f, v)
 		default:
 			expect(false, "unrecognized key %q for filtering", k)
 		}
@@ -443,7 +458,7 @@ func (p *parseState) field(f *field, v interface{}) {
 	// default equality check.
 	if !ok {
 		must(f.ValidateFn(v), "invalid datatype for field %q", f.Name)
-		p.WriteString(p.fmtOp(f.Name, EQ))
+		p.WriteString(p.fmtOp(f.Column, EQ))
 		p.values = append(p.values, f.CovertFn(v))
 	}
 	var i int
@@ -456,7 +471,7 @@ func (p *parseState) field(f *field, v interface{}) {
 		}
 		expect(f.FilterOps[opName], "can not apply op %q on field %q", opName, f.Name)
 		must(f.ValidateFn(opVal), "invalid datatype or format for field %q", f.Name)
-		p.WriteString(p.fmtOp(f.Name, Op(opName[1:])))
+		p.WriteString(p.fmtOp(f.Column, Op(opName[1:])))
 		p.values = append(p.values, f.CovertFn(opVal))
 		i++
 	}

--- a/rql_test.go
+++ b/rql_test.go
@@ -986,6 +986,65 @@ func TestParse(t *testing.T) {
 	}
 }
 
+func TestGetFields(t *testing.T) {
+	tests := []struct {
+		name    string
+		conf    Config
+		wantOut []*Field
+	}{
+		{
+			name: "get fields",
+			conf: Config{
+				Model: struct {
+					SomeName string `rql:"filter"`
+				}{},
+			},
+			wantOut: []*Field{
+				&Field{
+					Name:       "some_name",
+					Column:     "some_name",
+					Sortable:   false,
+					Filterable: true,
+					// AvailableOps: []string{"$eq", "$neq", "$lt", "$lte", "$gt", "$gte", "$like"},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p, err := NewParser(tt.conf)
+			if err != nil {
+				t.Fatalf("failed to build parser: %v", err)
+			}
+			out := p.GetFields()
+			assertFieldsEqual(t, out, tt.wantOut)
+		})
+	}
+}
+
+func assertFieldsEqual(t *testing.T, got []*Field, want []*Field) {
+
+	if len(got) != len(want) {
+		t.Fatalf("got %v, wanted %v", got, want)
+	}
+	for i := 0; i < len(got); i++ {
+		if got[i].Column != want[i].Column {
+			t.Fatalf("column got:%v want: %v", got[i].Column, want[i].Column)
+		}
+		if got[i].Filterable != want[i].Filterable {
+			t.Fatalf("Filterable got:%v want: %v", got[i].Filterable, want[i].Filterable)
+		}
+		if got[i].Sortable != want[i].Sortable {
+			t.Fatalf("Sortable got:%v want: %v", got[i].Sortable, want[i].Sortable)
+		}
+		if got[i].Name != want[i].Name {
+			t.Fatalf("Name got:%v want: %v", got[i].Name, want[i].Name)
+		}
+		// TODO: finish
+	}
+
+}
+
 // AssertQueryEqual tests if two query input are equal.
 // TODO: improve this in the future.
 func assertParams(t *testing.T, got *Params, want *Params) {

--- a/rql_test.go
+++ b/rql_test.go
@@ -912,6 +912,63 @@ func TestParse(t *testing.T) {
 			}`),
 			wantErr: true,
 		},
+		{
+			name: "support name struct opt",
+			conf: Config{
+				Model: struct {
+					SomeName string `rql:"filter,name=someName"`
+				}{},
+			},
+			input: []byte(`{
+				"filter": {
+					"someName": {
+						"$eq": "someName"
+					}
+				}
+			}`),
+			wantOut: &Params{
+				Limit:      25,
+				FilterExp:  "some_name = ?",
+				FilterArgs: []interface{}{"someName"},
+			},
+		},
+		{
+			name: "backwards compatibility to error with mismatching keys and no namefn",
+			conf: Config{
+				Model: struct {
+					SomeName string `rql:"filter"`
+				}{},
+			},
+			input: []byte(`{
+				"filter": {
+					"someName": {
+						"$eq": "someName"
+					}
+				}
+			}`),
+			wantErr: true,
+		},
+		{
+			name: "test nameFn works",
+			conf: Config{
+				Model: struct {
+					SomeName string `rql:"filter"`
+				}{},
+				NameFn: Column,
+			},
+			input: []byte(`{
+				"filter": {
+					"someName": {
+						"$eq": "someName"
+					}
+				}
+			}`),
+			wantOut: &Params{
+				Limit:      25,
+				FilterExp:  "some_name = ?",
+				FilterArgs: []interface{}{"someName"},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
includes https://github.com/a8m/rql/pull/47 

This adds functions to expose the internal fields object and to create a new parser from a slice of field objects. This lets the user dynamically configure a parser, my use case is to change rql config based on permissions. I would also like to expose the parsed data and related field information to be able to document related metadata for the user like what are available operations.

I think it would be nice to refactor to the following, but this is breaking:

```go
func NewParser(c Config, Model interface{}){}
func NewParserF(c Config,  fields []*Fields){}
``` 

Added: 
```go
func NewParserF(c Config, fields []*Field) (*Parser, error) {}
func (p *Parser) GetFields() []*Field {}
```