### PR TITLE
add support for custom db operations, validator and converter functions

### DIFF
--- a/config.go
+++ b/config.go
@@ -152,6 +152,12 @@ type Config struct {
 	GetDBOp func(Op) string
 	// Lets the user define how a rql dir ('+','-') is translated to a db direction.
 	GetDBDir func(Direction) string
+	// Sets the validator function based on the type
+	GetValidateFn func(reflect.Type) func(interface{}) error
+	// Sets the convertor function based on the type
+	GetConverter func(reflect.Type) func(interface{}) interface{}
+	// Sets the supported operations for that type
+	GetSupportedOps func(reflect.Type) []Op
 }
 
 // defaults sets the default configuration of Config.
@@ -177,6 +183,15 @@ func (c *Config) defaults() error {
 		c.GetDBDir = func(d Direction) string {
 			return sortDirection[d]
 		}
+	}
+	if c.GetConverter == nil {
+		c.GetConverter = GetConverterFn
+	}
+	if c.GetValidateFn == nil {
+		c.GetValidateFn = GetValidateFn
+	}
+	if c.GetSupportedOps == nil {
+		c.GetSupportedOps = GetSupportedOps
 	}
 	defaultString(&c.TagName, DefaultTagName)
 	defaultString(&c.OpPrefix, DefaultOpPrefix)

--- a/rql.go
+++ b/rql.go
@@ -291,7 +291,7 @@ func (p *Parser) parseField(sf reflect.StructField) error {
 	t := indirect(sf.Type)
 
 	filterOps := GetSupportedOps(t)
-	if len(f.FilterOps) == 0 {
+	if len(filterOps) == 0 {
 		return fmt.Errorf("rql: field type for %q is not supported", sf.Name)
 	}
 	f.CovertFn = GetConverterFn(t)


### PR DESCRIPTION
I need to add test coverage, but I wanted to see if there was any feedback before continuing. The current refactor gets a little weird with the timelayout function. I was thinking of adding, a map[string]string{} of 'Options' from the struct tag to the function signatures to fix support and any other weird edge cases like that. 

Refactored the main loop to separate out some of the concerns a bit and allow the user to override some of the core behavior for custom types and db operations. Its a little excessive but enables the user to handle custom types and ops.  

```go
	// Lets the user define how a rql op is translated to a db op.
	GetDBOp func(Op) string
	// Lets the user define how a rql dir ('+','-') is translated to a db direction.
	GetDBDir func(Direction) string
	// Sets the validator function based on the type
	GetValidateFn func(reflect.Type) func(interface{}) error
	// Sets the convertor function based on the type
	GetConverter func(reflect.Type) func(interface{}) interface{}
	// Sets the supported operations for that type
	GetSupportedOps func(reflect.Type) []Op
```

Alternatively I was thinking about doing something like:
```go
type Validator func(interface{}) error
type Converter func(interface{}) interface{}
GetFieldOps(reflect.Type) ([]Op, Validator, Converter)
``` 


What are your thoughts?