### PR TITLE
support custom ops

### DIFF
--- a/config.go
+++ b/config.go
@@ -8,14 +8,12 @@ import (
 
 // Op is a filter operator used by rql.
 type Op string
-
-// SQL returns the SQL representation of the operator.
-func (o Op) SQL() string {
-	return opFormat[o]
-}
+type Direction byte
 
 // Operators that support by rql.
 const (
+	ASC  = Direction('+')
+	DESC = Direction('-')
 	EQ   = Op("eq")   // =
 	NEQ  = Op("neq")  // <>
 	LT   = Op("lt")   // <
@@ -43,9 +41,9 @@ var (
 	// A sorting expression can be optionally prefixed with + or - to control the
 	// sorting direction, ascending or descending. For example, '+field' or '-field'.
 	// If the predicate is missing or empty then it defaults to '+'
-	sortDirection = map[byte]string{
-		'+': "asc",
-		'-': "desc",
+	sortDirection = map[Direction]string{
+		ASC:  "asc",
+		DESC: "desc",
 	}
 	opFormat = map[Op]string{
 		EQ:   "=",
@@ -59,6 +57,20 @@ var (
 		AND:  "AND",
 	}
 )
+
+func GetAllOps() []Op {
+	return []Op{
+		EQ,
+		NEQ,
+		LT,
+		GT,
+		LTE,
+		GTE,
+		LIKE,
+		OR,
+		AND,
+	}
+}
 
 // Config is the configuration for the parser.
 type Config struct {
@@ -136,6 +148,16 @@ type Config struct {
 	// DefaultSort is the default value for the 'Sort' field that returns when no sort expression is supplied by the caller.
 	// It defaults to an empty string slice.
 	DefaultSort []string
+	// Lets the user define how a rql op is translated to a db op.
+	GetDBOp func(Op) string
+	// Lets the user define how a rql dir ('+','-') is translated to a db direction.
+	GetDBDir func(Direction) string
+	// Sets the validator function based on the type
+	GetValidateFn func(reflect.Type) func(interface{}) error
+	// Sets the convertor function based on the type
+	GetConverter func(reflect.Type) func(interface{}) interface{}
+	// Sets the supported operations for that type
+	GetSupportedOps func(reflect.Type) []Op
 }
 
 // defaults sets the default configuration of Config.
@@ -151,6 +173,25 @@ func (c *Config) defaults() error {
 	}
 	if c.ColumnFn == nil {
 		c.ColumnFn = Column
+	}
+	if c.GetDBOp == nil {
+		c.GetDBOp = func(o Op) string {
+			return opFormat[o]
+		}
+	}
+	if c.GetDBDir == nil {
+		c.GetDBDir = func(d Direction) string {
+			return sortDirection[d]
+		}
+	}
+	if c.GetConverter == nil {
+		c.GetConverter = GetConverterFn
+	}
+	if c.GetValidateFn == nil {
+		c.GetValidateFn = GetValidateFn
+	}
+	if c.GetSupportedOps == nil {
+		c.GetSupportedOps = GetSupportedOps
 	}
 	defaultString(&c.TagName, DefaultTagName)
 	defaultString(&c.OpPrefix, DefaultOpPrefix)

--- a/rql_test.go
+++ b/rql_test.go
@@ -912,6 +912,47 @@ func TestParse(t *testing.T) {
 			}`),
 			wantErr: true,
 		},
+		{
+			name: "custom db symbols",
+			conf: Config{
+				Model: struct {
+					ID           string `rql:"filter"`
+					FullName     string `rql:"filter"`
+					HTTPUrl      string `rql:"filter"`
+					NestedStruct struct {
+						UUID string `rql:"filter"`
+					}
+				}{},
+				FieldSep: ".",
+				GetDBOp: func(o Op) string {
+					if o == EQ {
+						return "eq"
+					}
+					return opFormat[o]
+
+				},
+				GetDBDir: func(d Direction) string {
+					if d == ASC {
+						return "ASC"
+					}
+					return "DESC"
+				},
+			},
+			input: []byte(`{
+				"filter": {
+					"id": "id",
+					"full_name": "full_name",
+					"http_url": "http_url",
+					"nested_struct.uuid": "uuid"
+				}
+			}`),
+			wantOut: &Params{
+				Limit:      25,
+				FilterExp:  "id eq ? AND full_name eq ? AND http_url eq ? AND nested_struct_uuid eq ?",
+				FilterArgs: []interface{}{"id", "full_name", "http_url", "uuid"},
+				Sort:       "",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
I've added basic test coverage, but I wanted to see if there was any feedback before continuing. The current refactor gets a little weird with the time layout function. I was thinking of adding, a map[string]string{} of 'Options' from the struct tag to the function signatures to fix support and any other weird edge cases like that.

Refactored the main loop to separate out some of the concerns a bit and allow the user to override some of the core behavior for custom types and db operations. Its a little excessive but enables the user to handle custom types and ops. The user can also use the existing functionality and only override special cases. 

```go
	type Validator func(interface{}) error
	type Converter func(interface{}) interface{}
	// Lets the user define how a rql op is translated to a db op.
	GetDBOp func(Op) string
	// Lets the user define how a rql dir ('+','-') is translated to a db direction.
	GetDBDir func(Direction) string
	// Sets the validator function based on the type
	GetValidateFn func(reflect.Type) Validator
	// Sets the convertor function based on the type
	GetConverter func(reflect.Type) Converter
	// Sets the supported operations for that type
	GetSupportedOps func(reflect.Type) []Op
```

Alternatively I was thinking about doing something like:
```go
GetFieldOps(reflect.Type) ([]Op, Validator, Converter)
``` 


What are your thoughts?