### PR TITLE
expose field object publicly

### DIFF
--- a/rql_test.go
+++ b/rql_test.go
@@ -1021,3 +1021,56 @@ func mustParseTime(layout, s string) time.Time {
 	t, _ := time.Parse(layout, s)
 	return t
 }
+
+func TestGetFields(t *testing.T) {
+	tests := []struct {
+		name    string
+		conf    Config
+		wantOut []*Field
+	}{
+		{
+			name: "get fields",
+			conf: Config{
+				Model: struct {
+					SomeName string `rql:"filter"`
+				}{},
+			},
+			wantOut: []*Field{
+				&Field{
+					Name: "some_name",
+					// Column:     "some_name",
+					Sortable:   false,
+					Filterable: true,
+					// AvailableOps: []string{"$eq", "$neq", "$lt", "$lte", "$gt", "$gte", "$like"},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p, err := NewParser(tt.conf)
+			if err != nil {
+				t.Fatalf("failed to build parser: %v", err)
+			}
+			out := p.GetFields()
+			assertFieldsEqual(t, out, tt.wantOut)
+		})
+	}
+}
+
+func assertFieldsEqual(t *testing.T, got []*Field, want []*Field) {
+	if len(got) != len(want) {
+		t.Fatalf("got %v, wanted %v", got, want)
+	}
+	for i := 0; i < len(got); i++ {
+		if got[i].Filterable != want[i].Filterable {
+			t.Fatalf("Filterable got:%v want: %v", got[i].Filterable, want[i].Filterable)
+		}
+		if got[i].Sortable != want[i].Sortable {
+			t.Fatalf("Sortable got:%v want: %v", got[i].Sortable, want[i].Sortable)
+		}
+		if got[i].Name != want[i].Name {
+			t.Fatalf("Name got:%v want: %v", got[i].Name, want[i].Name)
+		}
+	}
+}


### PR DESCRIPTION
This adds functions to expose the internal fields object and to create a new parser from a slice of field objects. This lets the user dynamically configure a parser, my use case is to change rql config based on permissions. I would also like to expose the parsed data and related field information to be able to document related metadata for the user like what are available operations. I think it pairs well with https://github.com/a8m/rql/pull/51. 

I think it would be nice to refactor to the following, but this is breaking:

```go
func NewParser(c Config, Model interface{}){}
func NewParserF(c Config,  fields []*Fields){}
``` 

Added: 
```go
func NewParserF(c Config, fields []*Field) (*Parser, error) {}
func (p *Parser) GetFields() []*Field {}
```